### PR TITLE
修复两个初始化的bug

### DIFF
--- a/components/t-color-picker/t-color-picker.vue
+++ b/components/t-color-picker/t-color-picker.vue
@@ -241,7 +241,7 @@
 			 */
 			init() {
 				// hsb 颜色
-				this.hsb = this.rgbToHex(this.rgba);
+				this.hsb = this.rgbToHsb(this.rgba);
 				// this.setColor();
 				this.setValue(this.rgba);
 			},
@@ -305,6 +305,8 @@
 			 * 设置位置
 			 */
 			setPosition(x, y, index) {
+				if (!this.position) return;
+
 				this.index = index;
 				const {
 					top,


### PR DESCRIPTION
## bug 1
在组件首次open，窗口刚弹出时，立刻滑动颜色选择区，会出现以下报错
![image](https://user-images.githubusercontent.com/105833611/215497175-bc26769c-6ba9-49a7-9d97-3bb7694f841d.png)
原因：此时this的data还未准备好，`this.position`是`undefined`

## bug 2
窗口刚弹出时（不一定是首次），立刻滑动颜色选择区，会出现以下报错
![image](https://user-images.githubusercontent.com/105833611/215498094-f8ef20d0-f8fe-4198-975c-9c08ccea2678.png)
原因：`open`通过调用·的`init`和`getSelectorQuery`之间有一定延时，`init`中错将`this.hsb = this.rgbToHsb(this.rgba)`写成`this.hsb = this.rgbToHex(this.rgba)`，导致`this.hsb`短时间内是`String`


